### PR TITLE
Prepare for publication to GitHub Package Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Apple Receipt changelog
 
+## v0.2.3
+
+- Prepared for publication to GitHub Package Registry
+
 ## v0.2.2
 
 - Updated README to add information about validation [\#13](https://github.com/koenrh/apple_receipt/pull/13)
@@ -12,5 +16,6 @@
 ## v0.2.0
 
 - Added ISC license [\#5](https://github.com/koenrh/apple_receipt/pull/5)
-- Added missing dependencies ([\#3](https://github.com/koenrh/apple_receipt/pull/3) and [\#4](https://github.com/koenrh/apple_receipt/pull/4))
+- Added missing dependencies ([\#3](https://github.com/koenrh/apple_receipt/pull/3)
+  and [\#4](https://github.com/koenrh/apple_receipt/pull/4))
 - Added support for 'version 2' receipts ([\#1](https://github.com/koenrh/apple_receipt/pull/1))

--- a/apple_receipt.gemspec
+++ b/apple_receipt.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Local Apple receipt validation.'
   # spec.description   = %q{TODO: Write a longer description or delete this li
   spec.homepage      = 'https://github.com/koenrh/apple_receipt'
-  spec.license       = 'MIT'
+  spec.license       = 'ISC'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/apple_receipt.gemspec
+++ b/apple_receipt.gemspec
@@ -8,11 +8,11 @@ Gem::Specification.new do |spec|
   spec.name          = 'apple_receipt'
   spec.version       = AppleReceipt::VERSION
   spec.authors       = ['Koen Rouwhorst']
-  spec.email         = ['koenrh@blendle.com']
+  spec.email         = ['info@koenrouwhorst.nl']
 
   spec.summary       = 'Local Apple receipt validation.'
   # spec.description   = %q{TODO: Write a longer description or delete this li
-  spec.homepage      = 'https://www.blendle.com'
+  spec.homepage      = 'https://github.com/koenrh/apple_receipt'
   spec.license       = 'MIT'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|

--- a/apple_receipt.gemspec
+++ b/apple_receipt.gemspec
@@ -4,7 +4,6 @@ lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'apple_receipt/version'
 
-# rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |spec|
   spec.name          = 'apple_receipt'
   spec.version       = AppleReceipt::VERSION
@@ -15,13 +14,6 @@ Gem::Specification.new do |spec|
   # spec.description   = %q{TODO: Write a longer description or delete this li
   spec.homepage      = 'https://www.blendle.com'
   spec.license       = 'MIT'
-
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = 'https://rubygems.org'
-  else
-    raise 'RubyGems 2.0 or newer is required to protect against ' \
-      'public gem pushes.'
-  end
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
@@ -39,4 +31,3 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop', '~> 0.60'
 end
-# rubocop:enable Metrics/BlockLength

--- a/lib/apple_receipt/version.rb
+++ b/lib/apple_receipt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AppleReceipt
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end


### PR DESCRIPTION
Test publication of gem to the GitHub Package Registry.

Push command: `gem push --key github --host https://rubygems.pkg.github.com/koenrh pkg/apple_receipt-0.2.3.gem`